### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe shell command constructed from library input

### DIFF
--- a/lib/grack/git.rb
+++ b/lib/grack/git.rb
@@ -42,7 +42,11 @@ module Grack
     end
 
     def config_setting(service_name)
-      service_name = service_name.gsub('-', '')
+      service_name = service_name.to_s.gsub('-', '')
+      unless %w[uploadpack receivepack].include?(service_name)
+        raise ArgumentError, "Unsupported service name: #{service_name}"
+      end
+
       setting = config("http.#{service_name}")
 
       if service_name == 'uploadpack'
@@ -53,6 +57,11 @@ module Grack
     end
 
     def config(config_name)
+      config_name = config_name.to_s
+      unless /\Ahttp\.(uploadpack|receivepack)\z/.match?(config_name)
+        raise ArgumentError, "Unsupported config name: #{config_name}"
+      end
+
       execute(%W(config #{config_name}))
     end
 


### PR DESCRIPTION
Potential fix for [https://github.com/redmine-git-hosting/grack/security/code-scanning/1](https://github.com/redmine-git-hosting/grack/security/code-scanning/1)

To fix this without changing intended functionality, validate/allowlist the dynamic config key input before it is passed into git execution.

Best approach in this file:
- In `config_setting(service_name)`, normalize as today, then enforce `service_name` to be only known safe values used by this code (`uploadpack`, `receivepack`).
- In `config(config_name)`, enforce a strict format for config keys accepted by this class (here, `http.uploadpack` / `http.receivepack`), and reject anything else with `ArgumentError`.
- Keep using array-based `IO.popen` as-is.

This addresses all alert variants because both taint sources (`service_name`, `config_name`) are constrained before reaching `execute`/`command`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
